### PR TITLE
updates for 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: scala
 jdk:
 - openjdk8
 scala:
-- 2.11.12
 - 2.12.8
+- 2.13.0
 
 before_install:
 - git fetch --tags

--- a/build.sbt
+++ b/build.sbt
@@ -47,6 +47,7 @@ lazy val readme = project
     scalacOptions -= "-Ywarn-unused:imports",
     scalacOptions -= "-Ywarn-unused-import", // the same as above but for 2.11
     scalacOptions -= "-Wunused:imports",
+    scalacOptions -= "-deprecation",
     tutSourceDirectory := baseDirectory.value,
     tutTargetDirectory := (LocalRootProject / baseDirectory).value
   )

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,6 @@ val gitHubOwner = "fthomas"
 val moduleCrossPlatformMatrix: Map[String, List[Platform]] = Map(
   "core" -> List(JVMPlatform)
 )
-
 /// projects
 
 lazy val root = project
@@ -26,8 +25,14 @@ lazy val root = project
 
 lazy val core = myCrossProject("core")
   .settings(
+    crossScalaVersions += "2.13.0"
+  )
+  .settings(
     libraryDependencies ++= Seq(
-      Dependencies.cron4s,
+      scalaVersion.value match {
+        case "2.13.0" => Dependencies.cron4s13
+        case _ => Dependencies.cron4s12
+      },
       Dependencies.fs2Core,
       Dependencies.scalaTest % Test
     )

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,6 @@ lazy val readme = project
     scalacOptions -= "-Ywarn-unused:imports",
     scalacOptions -= "-Ywarn-unused-import", // the same as above but for 2.11
     scalacOptions -= "-Wunused:imports",
-    scalacOptions -= "-deprecation",
     tutSourceDirectory := baseDirectory.value,
     tutTargetDirectory := (LocalRootProject / baseDirectory).value
   )

--- a/build.sbt
+++ b/build.sbt
@@ -25,14 +25,8 @@ lazy val root = project
 
 lazy val core = myCrossProject("core")
   .settings(
-    crossScalaVersions += "2.13.0"
-  )
-  .settings(
     libraryDependencies ++= Seq(
-      scalaVersion.value match {
-        case "2.13.0" => Dependencies.cron4s13
-        case _ => Dependencies.cron4s12
-      },
+      Dependencies.cron4s,
       Dependencies.fs2Core,
       Dependencies.scalaTest % Test
     )

--- a/build.sbt
+++ b/build.sbt
@@ -46,6 +46,7 @@ lazy val readme = project
     fork in Tut := true,
     scalacOptions -= "-Ywarn-unused:imports",
     scalacOptions -= "-Ywarn-unused-import", // the same as above but for 2.11
+    scalacOptions -= "-Wunused:imports",
     tutSourceDirectory := baseDirectory.value,
     tutTargetDirectory := (LocalRootProject / baseDirectory).value
   )

--- a/modules/readme/README.md
+++ b/modules/readme/README.md
@@ -40,8 +40,8 @@ implicit val ctxShift: ContextShift[IO] = IO.contextShift(ExecutionContext.globa
 val everyFiveSeconds = Cron.unsafeParse("*/5 * * ? * *")
 
 val scheduledTasks = schedule(List(
-  evenSeconds      -> Stream.eval(IO(println(LocalTime.now + " task 1"))),
-  everyFiveSeconds -> Stream.eval(IO(println(LocalTime.now + " task 2")))
+  evenSeconds      -> Stream.eval(IO(println(LocalTime.now.toString + " task 1"))),
+  everyFiveSeconds -> Stream.eval(IO(println(LocalTime.now.toString + " task 2")))
 ))
 
 scheduledTasks.take(9).compile.drain.unsafeRunSync

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,8 @@
 import sbt._
 
 object Dependencies {
-  val cron4s = "com.github.alonsodomin.cron4s" %% "cron4s-core" % "0.5.0"
+  val cron4s13 = "com.github.alonsodomin.cron4s" %% "cron4s-core" % "0.6.0-M2"
+  val cron4s12 = "com.github.alonsodomin.cron4s" %% "cron4s-core" % "0.5.0"
   val fs2Core = "co.fs2" %% "fs2-core" % "2.0.0"
   val scalaTest = "org.scalatest" %% "scalatest" % "3.0.8"
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,8 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val cron4s13 = "com.github.alonsodomin.cron4s" %% "cron4s-core" % "0.6.0-M2"
-  val cron4s12 = "com.github.alonsodomin.cron4s" %% "cron4s-core" % "0.5.0"
+  val cron4s = "com.github.alonsodomin.cron4s" %% "cron4s-core" % "0.6.0-M2"
   val fs2Core = "co.fs2" %% "fs2-core" % "2.0.0"
   val scalaTest = "org.scalatest" %% "scalatest" % "3.0.8"
 }


### PR DESCRIPTION
upgrade cron4s to version supporting 2.13 Current version is a Milestone release, and they stopped publishing for 2.11 when they published for 2.13.

Compiles and tests run across all version, but haven't run this in anger yet.

This drops support for Scala 2.11