### PR TITLE
Use cats effect clock to determine current time

### DIFF
--- a/modules/core/src/main/scala/eu/timepit/fs2cron/package.scala
+++ b/modules/core/src/main/scala/eu/timepit/fs2cron/package.scala
@@ -59,11 +59,15 @@ package object fs2cron {
     * current date-time and the next date-time that matches `cronExpr`.
     */
   def durationFromNow[F[_]: Sync](cronExpr: CronExpr)(implicit
-      timezoneContext: TimezoneContext[F]
+      timezoneContext: TimezoneContext[F],
+      timer: Timer[F]
   ): Stream[F, FiniteDuration] = evalNow.flatMap(durationFrom(_, cronExpr))
 
   /** Creates a single element stream of the current date-time. */
-  def evalNow[F[_]: Sync](implicit timezoneContext: TimezoneContext[F]): Stream[F, ZonedDateTime] =
+  def evalNow[F[_]: Sync](implicit
+      timezoneContext: TimezoneContext[F],
+      timer: Timer[F]
+  ): Stream[F, ZonedDateTime] =
     Stream.eval(timezoneContext.now)
 
   /** Creates a single element stream that waits until the next


### PR DESCRIPTION
Fixes  #144 
After #151 was merged into master, `LocalDateTime` was replaced with `Instant.now()` and `ZoneDateTime` hence the concern mentioned in the issue regarding the usage of `LocalDateTime.now()` is redundant.