### PR TITLE
Update cron4s and fix tlBaseVersion

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ val moduleCrossPlatformMatrix: Map[String, List[Platform]] = Map(
 /// global settings
 
 ThisBuild / organization := groupId
-ThisBuild / tlBaseVersion := "0.9"
+ThisBuild / tlBaseVersion := "0.10"
 ThisBuild / startYear := Some(2018)
 ThisBuild / licenses := Seq(License.Apache2)
 ThisBuild / developers := List(
@@ -109,7 +109,7 @@ lazy val calev = myCrossProject("calev")
 lazy val cron4s = myCrossProject("cron4s")
   .dependsOn(core % "compile->compile;test->test")
   .settings(
-    libraryDependencies += "com.github.alonsodomin.cron4s" %% "cron4s-core" % "0.8.1",
+    libraryDependencies += "com.github.alonsodomin.cron4s" %% "cron4s-core" % "0.8.2",
     libraryDependencies ++= {
       if (scalaVersion.value.startsWith("2.12."))
         List(scalaOrganization.value % "scala-reflect" % scalaVersion.value)


### PR DESCRIPTION
Update cron4s to 0.8.2 and fix tlBaseVersion to 0.10.

A project I'm using needs 0.8.2 of cron4s for a bugfix, but I think because of the tlBaseVersion not being correct Scala Steward hasn't been running against this repo